### PR TITLE
update fqdn pattern

### DIFF
--- a/src/LTDBeget/dns/configurator/zoneEntities/record/CaaRecord.php
+++ b/src/LTDBeget/dns/configurator/zoneEntities/record/CaaRecord.php
@@ -22,8 +22,8 @@ class CaaRecord extends Record
     const TAG_ISSUEWILD = 'issuewild';
     /** @var string specifies a URL to which a certificate authority may report policy violations */
     const TAG_IODEF = 'iodef';
-    /** @var string  проверка по FQDN */
-    const PATTERN_FQDN = '/^([a-zа-яё0-9\_]([a-zа-яё0-9\-]{0,61}[a-zа-яё0-9])?\.)*([a-zа-яё0-9]([a-zа-яё0-9\-]{0,61}[a-zа-яё0-9])?\.)+[a-zа-яё0-9-]{2,30}$/i';
+    /** @var string  проверка по FQDN  rfc6844 5.2 */
+    const PATTERN_FQDN = '/^([a-z0-9\-]([a-z0-9\-]{0,61}[a-z0-9])?\.)*([a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z0-9-]{2,30}$/i';
 
     /**
      * @var Int


### PR DESCRIPTION
промахнулись с кирилицей для домена))

```
 Tag values MAY contain US-ASCII characters 'a' through 'z', 'A'
      through 'Z', and the numbers 0 through 9.  Tag values SHOULD NOT
      contain any other characters.  Matching of tag values is case
      insensitive.


```