### PR TITLE
Patched MX constructor 

### DIFF
--- a/src/LTDBeget/dns/configurator/zoneEntities/record/MxRecord.php
+++ b/src/LTDBeget/dns/configurator/zoneEntities/record/MxRecord.php
@@ -42,7 +42,7 @@ class MxRecord extends Record
     public function __construct(Node $node, $ttl, int $preference, string $exchange)
     {
         $this->preference = $preference;
-        $this->exchange   = $exchange;
+        $this->exchange   = $exchange!=='.' ? $exchange : $node->getZone()->getOrigin();
         parent::__construct($node, eRecordType::MX(), $ttl);
     }
 


### PR DESCRIPTION
so that it works with mailinabox.email weird zone files

https://mailinabox.email creates a weird MX record in the zone file. When it doesn't want to accept mail at a given subdomain, it will create a record that looks like this.

```
www	IN	MX	0 .
```

That trailing '.' is supposed to be the current root domain. 

I've patched the `__construct()` of `MxRecord` so that if the exchange === '.' then it uses the domain name.

This is an edge case. If it doesn't get accepted into the main code, I'm fine with that. I had to have it and figured I'd share in case anyone else needs it.

Thanks for this library, saved me a bunch of time and effort! :)

Cheers!
=C=
